### PR TITLE
Fixed and tidied `combinatorics.list_permutation` function

### DIFF
--- a/src/gleam_community/maths/combinatorics.gleam
+++ b/src/gleam_community/maths/combinatorics.gleam
@@ -350,28 +350,12 @@ fn do_list_combination(arr: List(a), k: Int, prefix: List(a)) -> List(List(a)) {
 pub fn list_permutation(arr: List(a)) -> List(List(a)) {
   case arr {
     [] -> [[]]
-    _ ->
-      flat_map(
-        arr,
-        fn(x) {
-          let remaining = list.filter(arr, fn(y) { x != y })
-          list.map(list_permutation(remaining), fn(perm) { [x, ..perm] })
-        },
-      )
+    _ -> {
+      use x <- list.flat_map(arr)
+      let assert Ok(#(_, remaining)) = list.pop(arr, fn(y) { x == y })
+      list.map(list_permutation(remaining), fn(perm) { [x, ..perm] })
+    }
   }
-}
-
-/// Flat map function
-fn flat_map(list: List(a), f: fn(a) -> List(b)) -> List(b) {
-  list
-  |> list.map(f)
-  |> concat()
-}
-
-/// Concatenate a list of lists
-fn concat(lists: List(List(a))) -> List(a) {
-  lists
-  |> list.fold([], list.append)
 }
 
 /// <div style="text-align: right;">

--- a/src/gleam_community/maths/combinatorics.gleam
+++ b/src/gleam_community/maths/combinatorics.gleam
@@ -319,6 +319,18 @@ fn do_list_combination(arr: List(a), k: Int, prefix: List(a)) -> List(List(a)) {
 ///
 /// Generate all permutations of a given list.
 ///
+/// Repeated elements are treated as distinct for the
+/// purpose of permutations, so two identical elements
+/// for example will appear "both ways round". This
+/// means lists with repeated elements return the same
+/// number of permutations as ones without.
+///
+/// N.B. The output of this function is a list of size
+/// factorial in the size of the input list. Caution is
+/// advised on input lists longer than ~11 elements, which
+/// may cause the VM to use unholy amounts of memory for
+/// the output.
+///
 /// <details>
 ///     <summary>Example:</summary>
 ///
@@ -338,6 +350,10 @@ fn do_list_combination(arr: List(a), k: Int, prefix: List(a)) -> List(List(a)) {
 ///         [2, 3, 1],
 ///         [3, 2, 1],
 ///       ]))
+///
+///       [1.0, 1.0]
+///       |> combinatorics.list_permutation()
+///       |> should.equal([[1.0, 1.0], [1.0, 1.0]])
 ///     }
 /// </details>
 ///

--- a/src/gleam_community/maths/combinatorics.gleam
+++ b/src/gleam_community/maths/combinatorics.gleam
@@ -368,6 +368,8 @@ pub fn list_permutation(arr: List(a)) -> List(List(a)) {
     [] -> [[]]
     _ -> {
       use x <- list.flat_map(arr)
+      // `x` is drawn from the list `arr` above,
+      // so Ok(...) can be safely asserted as the result of `list.pop` below
       let assert Ok(#(_, remaining)) = list.pop(arr, fn(y) { x == y })
       list.map(list_permutation(remaining), fn(perm) { [x, ..perm] })
     }

--- a/test/gleam/gleam_community_maths_combinatorics.gleam
+++ b/test/gleam/gleam_community_maths_combinatorics.gleam
@@ -1,5 +1,6 @@
 import gleam_community/maths/combinatorics
 import gleam/set
+import gleam/list
 import gleeunit
 import gleeunit/should
 
@@ -103,15 +104,22 @@ pub fn list_cartesian_product_test() {
 }
 
 pub fn list_permutation_test() {
-  // An empty lists returns an empty list
+  // An empty lists returns one (empty) permutation
   []
   |> combinatorics.list_permutation()
   |> should.equal([[]])
 
+  // Singleton returns one (singleton) permutation
+  // Also works regardless of type of list elements
+  ["a"]
+  |> combinatorics.list_permutation()
+  |> should.equal([["a"]])
+
   // Test with some arbitrary inputs
   [1, 2]
   |> combinatorics.list_permutation()
-  |> should.equal([[1, 2], [2, 1]])
+  |> set.from_list()
+  |> should.equal(set.from_list([[1, 2], [2, 1]]))
 
   // Test with some arbitrary inputs
   [1, 2, 3]
@@ -125,6 +133,20 @@ pub fn list_permutation_test() {
     [2, 3, 1],
     [3, 2, 1],
   ]))
+
+  // Repeated elements are treated as distinct for the
+  // purpose of permutations, so two identical elements
+  // will appear "both ways round"
+  [1.0, 1.0]
+  |> combinatorics.list_permutation()
+  |> should.equal([[1.0, 1.0], [1.0, 1.0]])
+
+  // This means lists with repeated elements return the
+  // same number of permutations as ones without
+  ["l", "e", "t", "t", "e", "r", "s"]
+  |> combinatorics.list_permutation()
+  |> list.length()
+  |> should.equal(5040)
 }
 
 pub fn list_combination_test() {


### PR DESCRIPTION
Hi, hope this is okay.

---

### The problem

I noticed an error in the implementation of the `combinatorics.list_permutation` function, when provided with lists containing duplicate items. For example (printing each permutation on a new line):

```
// (Old behaviour)
// [1, 1, 2] |> list_permutation 
[1, 2]
[1, 2]
[2, 1]
[2, 1]
```

Clearly, none of those are permutations of [1, 1, 2]! It did work correctly when given lists with unique elements:

```
// [1, 1, 2] |> list.unique |> list_permutation 
[1, 2]
[2, 1]
```

The issue was the use of `filter` on line 357. This removed from the remaining list all duplicates of `x`, when it shouldn't have.

---

### New behaviour

When fixing this, I considered two reasonable behaviours for list_permutations:

* __A__: Treat duplicate elements as distinct for the purposes of permutations. For example, the list [1, 1] has two permutations... [1, 1] (the same way round) and [1, 1] (the other way round). With this behaviour all lists of the same length will have the same number of permutations, namely `factorial(list.length(whichever_list))`.
* __B__: Treat duplicate elements as identical for the purposes of permutations. In this case, the list [1, 1] has only one permutation... itself. With this behaviour lists with duplicate elements will have fewer permutations than other lists of the same length.

Both behaviours are plausibly useful. I have decided, for this pull request, to implement behaviour A. Partly because it was a simpler change to write, but also because I think it is slightly more versatile: if you need behaviour B it is as simple as calling the function with behaviour A, and then piping the result to `list.unique`:

```
// (New behaviour)
// [1, 1, 2] |> list_permutation
[1, 1, 2]
[1, 2, 1]
[1, 1, 2]
[1, 2, 1]
[2, 1, 1]
[2, 1, 1]

// (Simulating behaviour B)
// [1, 1, 2] |> list_permutation |> list.unique
[1, 1, 2]
[1, 2, 1]
[2, 1, 1]
```

To implement this new behaviour, I switched from `filter` to `pop`. This always removes exactly one instance of `x`, leaving its duplicates in the remainder of the list. One difficulty is that `pop` returns a result in case the element it's searching for isn't in the list. But it always will be (as `x` is drawn from the list in the line above), so we can be sure to get an `Ok(...)` and I use a `let assert` expression to destructure this.

This is not exactly the most efficient way to write this function, but it has the same performance as what was there before, and is fairly readable. I would be happy to write a more efficient version if needed.

---

### Other changes

I made a few other code changes at the same time. These do not have any effect on the behaviour of the function.

* I noticed we were using local definitions of `flat_map` and `concat` for the implementation of `list_permutation` (and nothing else). As these are standard library functions (in the list module, which we already import) we don't need to duplicate them locally, so I got rid of them.
* I rewrote the call to `flat_map` on line 354 to use `use`. Personally, I find this more readable.

---

### To do

I have not yet:

* Added the above examples (or similar) as tests.
* Updated the documentation to explain the behaviour with duplicates.